### PR TITLE
Add unique scalar queries and fix nested relation resolution

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -316,6 +316,14 @@ Returns a single integer (`{"count": N}`) for the same filter semantics.
 When `aggregates` is requested, returns both `count` and aggregate values in one response.
 `/api/count` is kept as a backward-compatible deprecated alias.
 
+Both `/api/index` and `/api/stats` accept an optional `unique_by` field for
+scalar unique-value mode. `/api/index` returns a flat, ascending array of unique
+values and ignores the preset; `/api/stats` returns their count as
+`{"count": N}`. Filters retain their normal join semantics, including filters
+through `has_many`, while `unique_by` itself may not traverse `has_many`.
+`null` is treated as one distinct value. Pagination on `/api/index` is applied
+after deduplication. Aggregate requests cannot be combined with `unique_by`.
+
 Payload:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -222,6 +222,31 @@ Behavior notes:
 - invalid payloads return `400`
 - SQL/build/runtime errors return `500`
 
+#### Unique scalar values
+
+Set `unique_by` to return only the unique values of one field. In this mode
+the preset is ignored, relation tails are not loaded, and the response is a
+flat JSON array:
+
+```json
+{
+  "model": "Employee",
+  "preset": "ignored_in_this_mode",
+  "filters": {"organization_id__gte": 1},
+  "unique_by": "position",
+  "offset": 0,
+  "limit": 20
+}
+```
+
+```json
+["Developer", "Manager"]
+```
+
+Values are ordered ascending. `limit` and `offset` apply after deduplication,
+and `null` is included as one unique value. Dotted `belongs_to` and `has_one`
+paths are supported; paths traversing `has_many` are rejected as ambiguous.
+
 ### `POST /api/stats`
 
 Returns a single integer count for the same filter semantics.
@@ -238,6 +263,19 @@ Payload:
   }
 }
 ```
+
+To count unique scalar values instead of root records, pass `unique_by`:
+
+```json
+{
+  "model": "Employee",
+  "filters": {},
+  "unique_by": "position"
+}
+```
+
+The response remains `{"count": N}` and includes `null` as one unique value.
+`aggregates` cannot be combined with `unique_by`.
 
 Response:
 

--- a/internal/handler/index.go
+++ b/internal/handler/index.go
@@ -2,9 +2,11 @@ package handler
 
 import (
 	"YrestAPI/internal/logger"
+	"YrestAPI/internal/model"
 	"YrestAPI/internal/resolver"
 
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 )
@@ -45,6 +47,25 @@ func IndexHandler(w http.ResponseWriter, r *http.Request) {
 		"endpoint": "/api/index",
 		"payload":  json.RawMessage(body),
 	})
+
+	if req.UniqueBy != "" {
+		result, err := resolver.ResolveDistinctValues(r.Context(), req)
+		if err != nil {
+			status := http.StatusInternalServerError
+			var validationErr *model.DistinctValidationError
+			if errors.As(err, &validationErr) {
+				status = http.StatusBadRequest
+			}
+			logger.Error("distinct_resolver_error", map[string]any{"endpoint": "/api/index", "error": err.Error()})
+			http.Error(w, "Failed to resolve distinct values: "+err.Error(), status)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(result); err != nil {
+			logger.Error("write_response_failed", map[string]any{"endpoint": "/api/index", "error": err.Error()})
+		}
+		return
+	}
 
 	// Вызываем Resolver
 	result, err := resolver.Resolver(r.Context(), req)

--- a/internal/handler/stats.go
+++ b/internal/handler/stats.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,6 +18,7 @@ type StatsRequest struct {
 	Model      string                        `json:"model"`
 	Preset     string                        `json:"preset"`
 	Filters    map[string]interface{}        `json:"filters"`
+	UniqueBy   string                        `json:"unique_by"`
 	Aggregates map[string]StatsAggregateSpec `json:"aggregates"`
 }
 
@@ -62,6 +64,43 @@ func StatsHandler(w http.ResponseWriter, r *http.Request) {
 			"model":    req.Model,
 		})
 		http.Error(w, fmt.Sprintf("Model %s not found", req.Model), http.StatusNotFound)
+		return
+	}
+	if strings.TrimSpace(req.UniqueBy) != "" {
+		if len(req.Aggregates) > 0 {
+			http.Error(w, "aggregates cannot be combined with unique_by", http.StatusBadRequest)
+			return
+		}
+		filters := model.NormalizeFiltersWithAliases(m, req.Filters)
+		field := strings.TrimSpace(model.ExpandAliasPath(m, req.UniqueBy))
+		aliasMap, err := m.CreateAliasMap(m, nil, filters, []string{field + " ASC"})
+		if err != nil {
+			http.Error(w, "alias map error: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		query, err := m.BuildDistinctCountQuery(aliasMap, filters, field)
+		if err != nil {
+			status := http.StatusInternalServerError
+			var validationErr *model.DistinctValidationError
+			if errors.As(err, &validationErr) {
+				status = http.StatusBadRequest
+			}
+			http.Error(w, "Query error: "+err.Error(), status)
+			return
+		}
+		sqlStr, args, err := query.ToSql()
+		if err != nil {
+			http.Error(w, "SQL error: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		logger.Debug("sql", map[string]any{"endpoint": endpoint, "sql": sqlStr, "args": args})
+		var count int
+		if err := db.Pool.QueryRow(r.Context(), sqlStr, args...).Scan(&count); err != nil {
+			http.Error(w, "DB error: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]int{"count": count})
 		return
 	}
 

--- a/internal/itests/http_index_test.go
+++ b/internal/itests/http_index_test.go
@@ -16,6 +16,49 @@ import (
 	"YrestAPI/internal/db"
 )
 
+func Test_Index_DistinctValues_IgnoresPreset(t *testing.T) {
+	if testBaseURL == "" || httpSrv == nil {
+		t.Fatal("bootstrap not ready: HTTP server/baseURL missing")
+	}
+
+	rows, err := db.Pool.Query(context.Background(), `SELECT DISTINCT position FROM employees ORDER BY position ASC`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	want := make([]any, 0)
+	for rows.Next() {
+		var value any
+		if err := rows.Scan(&value); err != nil {
+			t.Fatal(err)
+		}
+		want = append(want, value)
+	}
+
+	payload := map[string]any{
+		"model":     "Employee",
+		"preset":    "this_preset_does_not_exist",
+		"unique_by": "position",
+	}
+	body, _ := json.Marshal(payload)
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Post(testBaseURL+"/api/index", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	responseBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, responseBody)
+	}
+	var got []any
+	if err := json.Unmarshal(responseBody, &got); err != nil {
+		t.Fatalf("expected scalar JSON array: %v; body=%s", err, responseBody)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("distinct values mismatch: got %#v, want %#v", got, want)
+	}
+}
+
 // /api/index: Employee, preset=item, order by id ASC, offset=1, limit=2
 func Test_Index_Employee_Item_Pagination(t *testing.T) {
 	if testBaseURL == "" || httpSrv == nil {

--- a/internal/itests/http_stats_test.go
+++ b/internal/itests/http_stats_test.go
@@ -11,6 +11,38 @@ import (
 	"time"
 )
 
+func Test_Stats_DistinctValuesCount_IgnoresPreset(t *testing.T) {
+	if testBaseURL == "" || httpSrv == nil {
+		t.Fatal("bootstrap not ready: HTTP server/baseURL missing")
+	}
+	var want int
+	if err := db.Pool.QueryRow(context.Background(), `SELECT COUNT(*) FROM (SELECT DISTINCT position FROM employees) distinct_values`).Scan(&want); err != nil {
+		t.Fatal(err)
+	}
+	payload := map[string]any{
+		"model":     "Employee",
+		"preset":    "this_preset_does_not_exist",
+		"unique_by": "position",
+	}
+	body, _ := json.Marshal(payload)
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Post(testBaseURL+"/api/stats", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	responseBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, responseBody)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(responseBody, &got); err != nil {
+		t.Fatal(err)
+	}
+	if count := extractCount(got); count != want {
+		t.Fatalf("distinct count mismatch: got %d, want %d; body=%s", count, want, responseBody)
+	}
+}
+
 // Deprecated /api/count alias should still return plain stats payloads.
 func Test_Stats_DeprecatedCountAlias_Person_Item(t *testing.T) {
 	if testBaseURL == "" || httpSrv == nil {

--- a/internal/model/distinct.go
+++ b/internal/model/distinct.go
@@ -1,0 +1,130 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/squirrel"
+)
+
+// DistinctValidationError denotes an invalid client-provided unique_by field.
+type DistinctValidationError struct {
+	Message string
+}
+
+func (e *DistinctValidationError) Error() string { return e.Message }
+
+// ResolveDistinctField validates a field path and resolves it to a SQL expression.
+// A has_many path is deliberately rejected: one root row can have several values.
+func (m *Model) ResolveDistinctField(aliasMap *AliasMap, field string) (string, string, error) {
+	field = strings.TrimSpace(ExpandAliasPath(m, field))
+	if field == "" {
+		return "", "", &DistinctValidationError{Message: "unique_by field is required"}
+	}
+
+	segs := strings.Split(field, ".")
+	curr := m
+	for i, seg := range segs {
+		if !identRe.MatchString(seg) || isSQLKeyword(seg) {
+			return "", "", &DistinctValidationError{Message: fmt.Sprintf("invalid unique_by field %q", field)}
+		}
+		if i == len(segs)-1 {
+			break
+		}
+		rel := curr.Relations[seg]
+		if rel == nil || rel.GetModelRef() == nil || rel.Polymorphic {
+			return "", "", &DistinctValidationError{Message: fmt.Sprintf("relation %q not found for unique_by", strings.Join(segs[:i+1], "."))}
+		}
+		if rel.Type == "has_many" {
+			return "", "", &DistinctValidationError{Message: fmt.Sprintf("unique_by field %q traverses has_many relation %q", field, strings.Join(segs[:i+1], "."))}
+		}
+		curr = rel.GetModelRef()
+	}
+
+	expr, ok := m.resolveFieldExpression(nil, aliasMap, field)
+	if !ok || strings.TrimSpace(expr) == "" || isAggregateExpr(expr) {
+		return "", "", &DistinctValidationError{Message: fmt.Sprintf("could not resolve unique_by field %q", field)}
+	}
+	return field, expr, nil
+}
+
+// BuildDistinctValuesQuery builds a scalar list query. Presets are intentionally
+// absent: only the requested value is selected, while filters keep their normal
+// join/has_many/HAVING semantics.
+func (m *Model) BuildDistinctValuesQuery(aliasMap *AliasMap, filters map[string]interface{}, field string, offset, limit uint64) (squirrel.SelectBuilder, error) {
+	filters = NormalizeFiltersWithAliases(m, filters)
+	field, expr, err := m.ResolveDistinctField(aliasMap, field)
+	if err != nil {
+		return squirrel.SelectBuilder{}, err
+	}
+
+	base := squirrel.SelectBuilder{}.PlaceholderFormat(squirrel.Dollar).From(fmt.Sprintf("%s AS main", m.Table))
+	filterKeys := PathsFromFilters(filters)
+	requestSorts := []string{field + " ASC"}
+	compPaths := collectComputablePathsForRequest(m, nil, filters, requestSorts)
+	joins, err := m.DetectJoins(aliasMap, filterKeys, []string{field}, compPaths)
+	if err != nil {
+		return base, err
+	}
+
+	cteSpecs, computableOverride, skipAliases := buildHasManyCTEs(m, nil, filters, requestSorts, aliasMap, joins)
+	if len(cteSpecs) > 0 {
+		prefixSQL, prefixArgs, err := buildCTEQueries(m, cteSpecs)
+		if err != nil {
+			return base, err
+		}
+		base = base.Prefix(prefixSQL, prefixArgs...)
+		for _, spec := range cteSpecs {
+			base = base.LeftJoin(fmt.Sprintf("%s ON %s.id = main.id", spec.Name, spec.Name))
+		}
+	}
+	joins = filterJoinSpecs(joins, skipAliases)
+	for _, join := range joins {
+		onClause := join.On
+		if join.Where != "" {
+			onClause = fmt.Sprintf("(%s) AND (%s)", join.On, join.Where)
+		}
+		base = base.LeftJoin(fmt.Sprintf("%s AS %s ON %s", join.Table, join.Alias, onClause))
+	}
+
+	wherePart, havingPart, err := m.buildWhereClause(aliasMap, nil, filters, joins, computableOverride)
+	if err != nil {
+		return base, err
+	}
+	if wherePart != nil {
+		base = base.Where(wherePart)
+	}
+
+	var query squirrel.SelectBuilder
+	if havingPart == nil {
+		query = base.Column(fmt.Sprintf("DISTINCT %s AS value", expr))
+	} else {
+		groupBy := make([]string, 0, len(m.GetPrimaryKeys())+1)
+		for _, key := range m.GetPrimaryKeys() {
+			groupBy = append(groupBy, "main."+key)
+		}
+		groupBy = append(groupBy, expr)
+		inner := base.Column(fmt.Sprintf("%s AS value", expr)).GroupBy(groupBy...).Having(havingPart)
+		query = squirrel.SelectBuilder{}.PlaceholderFormat(squirrel.Dollar).
+			Column("DISTINCT distinct_roots.value AS value").
+			FromSelect(inner, "distinct_roots")
+	}
+
+	query = query.OrderBy("value ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	if offset > 0 {
+		query = query.Offset(offset)
+	}
+	return query, nil
+}
+
+func (m *Model) BuildDistinctCountQuery(aliasMap *AliasMap, filters map[string]interface{}, field string) (squirrel.SelectBuilder, error) {
+	values, err := m.BuildDistinctValuesQuery(aliasMap, filters, field, 0, 0)
+	if err != nil {
+		return squirrel.SelectBuilder{}, err
+	}
+	return squirrel.SelectBuilder{}.PlaceholderFormat(squirrel.Dollar).
+		Column("COUNT(*)").FromSelect(values, "distinct_values"), nil
+}

--- a/internal/model/distinct_test.go
+++ b/internal/model/distinct_test.go
@@ -1,0 +1,89 @@
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildDistinctValuesQuerySimpleFieldIgnoresPreset(t *testing.T) {
+	m := &Model{Name: "Person", Table: "people", Relations: map[string]*ModelRelation{}, Computable: map[string]*Computable{}}
+	am, err := BuildAliasMap(m, nil, nil, []string{"department_id ASC"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	query, err := m.BuildDistinctValuesQuery(am, nil, "department_id", 5, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql, _, err := query.ToSql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"SELECT DISTINCT main.department_id AS value", "ORDER BY value ASC", "LIMIT 10", "OFFSET 5"} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("expected %q in SQL: %s", want, sql)
+		}
+	}
+}
+
+func TestBuildDistinctValuesQueryKeepsHasManyFilterDeduplication(t *testing.T) {
+	child := &Model{Name: "Membership", Table: "memberships", Relations: map[string]*ModelRelation{}, Computable: map[string]*Computable{}}
+	m := &Model{
+		Name: "Person", Table: "people", Computable: map[string]*Computable{},
+		Relations: map[string]*ModelRelation{
+			"memberships": {Type: "has_many", Model: "Membership", FK: "person_id", PK: "id"},
+		},
+	}
+	m.Relations["memberships"].SetModelRef(child)
+	filters := map[string]any{"memberships.active__eq": true}
+	am, err := BuildAliasMap(m, nil, filters, []string{"department_id ASC"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	query, err := m.BuildDistinctValuesQuery(am, filters, "department_id", 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql, _, err := query.ToSql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(sql, "LEFT JOIN memberships AS") || !strings.Contains(sql, "SELECT DISTINCT main.department_id AS value") {
+		t.Fatalf("expected has_many join and scalar deduplication: %s", sql)
+	}
+}
+
+func TestResolveDistinctFieldRejectsHasManyPath(t *testing.T) {
+	child := &Model{Name: "Membership", Table: "memberships", Relations: map[string]*ModelRelation{}, Computable: map[string]*Computable{}}
+	m := &Model{Name: "Person", Table: "people", Computable: map[string]*Computable{}, Relations: map[string]*ModelRelation{
+		"memberships": {Type: "has_many", Model: "Membership", FK: "person_id", PK: "id"},
+	}}
+	m.Relations["memberships"].SetModelRef(child)
+	am, err := BuildAliasMap(m, nil, nil, []string{"memberships.role ASC"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = m.ResolveDistinctField(am, "memberships.role")
+	if err == nil || !strings.Contains(err.Error(), "traverses has_many") {
+		t.Fatalf("expected has_many validation error, got %v", err)
+	}
+}
+
+func TestBuildDistinctCountIncludesNullGroup(t *testing.T) {
+	m := &Model{Name: "Person", Table: "people", Relations: map[string]*ModelRelation{}, Computable: map[string]*Computable{}}
+	am, err := BuildAliasMap(m, nil, nil, []string{"department_id ASC"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	query, err := m.BuildDistinctCountQuery(am, nil, "department_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql, _, err := query.ToSql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(sql, "COUNT(*)") || !strings.Contains(sql, "SELECT DISTINCT main.department_id AS value") || strings.Contains(sql, "COUNT(DISTINCT") {
+		t.Fatalf("count must wrap the distinct value set (including NULL): %s", sql)
+	}
+}

--- a/internal/resolver/apply_all_formatters_test.go
+++ b/internal/resolver/apply_all_formatters_test.go
@@ -314,3 +314,76 @@ func TestApplyAllFormatters_NestedPreset_LocalFormatter(t *testing.T) {
 		t.Fatalf("nested formatter failed: got %#v", items[0])
 	}
 }
+
+func TestApplyAllFormatters_DoesNotCreateNilBelongsToContext(t *testing.T) {
+	organizationItem := &model.DataPreset{
+		Name: "item",
+		Fields: []model.Field{
+			{Type: "string", Source: "name"},
+		},
+	}
+	organization := &model.Model{
+		Table:     "organizations",
+		Relations: map[string]*model.ModelRelation{},
+		Presets:   map[string]*model.DataPreset{"item": organizationItem},
+	}
+
+	supplierItem := &model.DataPreset{
+		Name: "item",
+		Fields: []model.Field{
+			{
+				Type:         "preset",
+				Source:       "organization",
+				Alias:        "name",
+				Formatter:    "{name}",
+				NestedPreset: "item",
+			},
+		},
+	}
+	supplier := &model.Model{
+		Table:   "suppliers",
+		Presets: map[string]*model.DataPreset{"item": supplierItem},
+		Relations: map[string]*model.ModelRelation{
+			"organization": {Type: "has_one"},
+		},
+	}
+	supplier.Relations["organization"].SetModelRef(organization)
+
+	orderStage := &model.DataPreset{
+		Name: "stage",
+		Fields: []model.Field{
+			{Type: "preset", Source: "supplier", NestedPreset: "item"},
+		},
+	}
+	order := &model.Model{
+		Table:   "orders",
+		Presets: map[string]*model.DataPreset{"stage": orderStage},
+		Relations: map[string]*model.ModelRelation{
+			"supplier": {Type: "belongs_to"},
+		},
+	}
+	order.Relations["supplier"].SetModelRef(supplier)
+
+	stageOrderCard := &model.DataPreset{
+		Name: "card",
+		Fields: []model.Field{
+			{Type: "preset", Source: "order", NestedPreset: "stage"},
+		},
+	}
+	stageOrder := &model.Model{
+		Table: "stage_orders",
+		Relations: map[string]*model.ModelRelation{
+			"order": {Type: "belongs_to"},
+		},
+	}
+	stageOrder.Relations["order"].SetModelRef(order)
+
+	items := []map[string]any{{"id": 1, "order": nil}}
+
+	if err := applyAllFormatters(stageOrder, stageOrderCard, items, ""); err != nil {
+		t.Fatalf("applyAllFormatters error: %v", err)
+	}
+	if got := items[0]["order"]; got != nil {
+		t.Fatalf("nil belongs_to context was materialized: %#v", got)
+	}
+}

--- a/internal/resolver/finalizeItems.go
+++ b/internal/resolver/finalizeItems.go
@@ -400,9 +400,7 @@ func applyAllFormatters(m *model.Model, p *model.DataPreset, items []map[string]
 					continue
 				}
 			}
-			mm := map[string]any{}
-			cur[seg] = mm
-			cur = mm
+			return nil
 		}
 		return cur
 	}
@@ -502,6 +500,9 @@ func applyAllFormatters(m *model.Model, p *model.DataPreset, items []map[string]
 					key := fieldKey(&f) // куда кладём ветку в JSON (alias > source)
 					for i := range items {
 						parent := getCtx(items[i], prefix)
+						if parent == nil {
+							continue
+						}
 						switch rel.Type {
 						case "has_one":
 							if sub, ok := parent[key].(map[string]any); ok {
@@ -571,6 +572,9 @@ func applyAllFormatters(m *model.Model, p *model.DataPreset, items []map[string]
 			target := f.Alias
 			for i := range items {
 				ctx := getCtx(items[i], prefix) // строго своя ветка
+				if ctx == nil {
+					continue
+				}
 				ctx[target] = applyFormatter(tpl, ctx)
 			}
 
@@ -596,6 +600,9 @@ func applyAllFormatters(m *model.Model, p *model.DataPreset, items []map[string]
 			for i := range items {
 				if val, ok := getValueAtPath(items[i], path); ok {
 					ctx := getCtx(items[i], prefix)
+					if ctx == nil {
+						continue
+					}
 					ctx[targetKey] = val
 				}
 			}
@@ -610,6 +617,9 @@ func applyAllFormatters(m *model.Model, p *model.DataPreset, items []map[string]
 			childPrefixAli := prefixFor(prefix, fieldKey(f))
 			for i := range items {
 				parent := getCtx(items[i], prefix)
+				if parent == nil {
+					continue
+				}
 
 				var child map[string]any
 				if m, ok := getMapAt(items[i], childPrefixSrc); ok {

--- a/internal/resolver/merge_tail_targetpath_test.go
+++ b/internal/resolver/merge_tail_targetpath_test.go
@@ -137,3 +137,24 @@ func TestMergeTailsUsesTargetPathContext(t *testing.T) {
 		}
 	}
 }
+
+func TestTailKeyIncludesTargetPath(t *testing.T) {
+	supplierName := TailSpec{
+		FieldAlias: "name",
+		TargetPath: "order.supplier",
+	}
+	contractorName := TailSpec{
+		FieldAlias: "name",
+		TargetPath: "stage.contract.contragent",
+	}
+
+	if got, want := tailKey(supplierName), "order.supplier.name"; got != want {
+		t.Fatalf("supplier tail key: got %q, want %q", got, want)
+	}
+	if got, want := tailKey(contractorName), "stage.contract.contragent.name"; got != want {
+		t.Fatalf("contractor tail key: got %q, want %q", got, want)
+	}
+	if tailKey(supplierName) == tailKey(contractorName) {
+		t.Fatal("tails from different target paths must not share an identity")
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -9,7 +9,60 @@ import (
 	"YrestAPI/internal/db"
 	"YrestAPI/internal/logger"
 	"YrestAPI/internal/model"
+	"github.com/google/uuid"
 )
+
+// ResolveDistinctValues returns a scalar unique-value list and deliberately
+// bypasses presets and relation-tail hydration.
+func ResolveDistinctValues(ctx context.Context, req IndexRequest) ([]any, error) {
+	m, ok := model.Registry[req.Model]
+	if !ok {
+		return nil, fmt.Errorf("resolver: model not found: %s", req.Model)
+	}
+	filters := model.NormalizeFiltersWithAliases(m, req.Filters)
+	field := strings.TrimSpace(model.ExpandAliasPath(m, req.UniqueBy))
+	aliasMap, err := m.CreateAliasMap(m, nil, filters, []string{field + " ASC"})
+	if err != nil {
+		return nil, &model.DistinctValidationError{Message: err.Error()}
+	}
+	query, err := m.BuildDistinctValuesQuery(aliasMap, filters, field, req.Offset, req.Limit)
+	if err != nil {
+		return nil, err
+	}
+	sqlStr, args, err := query.ToSql()
+	if err != nil {
+		return nil, err
+	}
+	logger.Debug("sql", map[string]any{"endpoint": "/api/index", "sql": sqlStr, "args": args})
+	rows, err := db.Pool.Query(ctx, sqlStr, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	values := make([]any, 0)
+	for rows.Next() {
+		var value any
+		if err := rows.Scan(&value); err != nil {
+			return nil, err
+		}
+		switch v := value.(type) {
+		case uuid.UUID:
+			value = v.String()
+		case [16]byte:
+			if id, err := uuid.FromBytes(v[:]); err == nil {
+				value = id.String()
+			}
+		case []byte:
+			value = string(v)
+		}
+		values = append(values, value)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
 
 // Главный резолвер
 func Resolver(ctx context.Context, req IndexRequest) ([]map[string]any, error) {
@@ -92,7 +145,7 @@ func Resolver(ctx context.Context, req IndexRequest) ([]map[string]any, error) {
 
 	// 3) Собираем parentIDs отдельно для КАЖДОГО хвоста, используя rel.PK
 	type idSet map[any]struct{}
-	parentIDsByTail := make(map[string][]any) // FieldAlias -> []id
+	parentIDsByTail := make(map[string][]any) // full tail path -> []id
 
 	for _, t := range tails {
 		// ключ родителя, который участвует в связи
@@ -111,11 +164,11 @@ func Resolver(ctx context.Context, req IndexRequest) ([]map[string]any, error) {
 				}
 			}
 		}
-		parentIDsByTail[t.FieldAlias] = ids
+		parentIDsByTail[tailKey(t)] = ids
 	}
 
 	type grouped = map[any][]map[string]any
-	groupedByAlias := make(map[string]grouped)
+	groupedByTail := make(map[string]grouped)
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex
@@ -123,12 +176,13 @@ func Resolver(ctx context.Context, req IndexRequest) ([]map[string]any, error) {
 
 	for _, t := range tails {
 		t := t // avoid capturing loop variable in goroutine
-		ids := parentIDsByTail[t.FieldAlias]
+		key := tailKey(t)
+		ids := parentIDsByTail[key]
 		if len(ids) == 0 {
 			continue
 		}
 		wg.Add(1)
-		go func(ids []any) {
+		go func(key string, ids []any) {
 			defer wg.Done()
 
 			childModel := t.Rel.GetModelRef()
@@ -203,9 +257,9 @@ func Resolver(ctx context.Context, req IndexRequest) ([]map[string]any, error) {
 			}
 
 			mu.Lock()
-			groupedByAlias[t.FieldAlias] = g
+			groupedByTail[key] = g
 			mu.Unlock()
-		}(ids)
+		}(key, ids)
 	}
 
 	wg.Wait()
@@ -233,7 +287,7 @@ func Resolver(ctx context.Context, req IndexRequest) ([]map[string]any, error) {
 
 			// Получаем группы дочерних записей
 			var groups []map[string]any
-			if m, ok := groupedByAlias[t.FieldAlias]; ok {
+			if m, ok := groupedByTail[tailKey(t)]; ok {
 				if g, ok := m[pid]; ok {
 					groups = g
 				}
@@ -399,6 +453,13 @@ type TailSpec struct {
 	TargetPath   string // если задано, кладём результат в TargetPathCtx[FieldAlias]
 	Formatter    string // возможно мусорное поле,
 	// так как форматтеры на has_one/has_many считаются в дочерних вызовах резолвера
+}
+
+// tailKey identifies a hydrated has_one/has_many field within the complete
+// preset tree. FieldAlias alone is not unique: different nested branches may
+// legitimately expose fields with the same JSON name.
+func tailKey(t TailSpec) string {
+	return prefixFor(strings.TrimSpace(t.TargetPath), t.FieldAlias)
 }
 
 type PolyTailSpec struct {

--- a/internal/resolver/types.go
+++ b/internal/resolver/types.go
@@ -10,6 +10,7 @@ type IndexRequest struct {
 	Sorts         []string               `json:"sorts"`
 	Offset        uint64                 `json:"offset"`
 	Limit         uint64                 `json:"limit"`
+	UniqueBy      string                 `json:"unique_by"`
 	ThroughFor    string                 `json:"-"` // имя связи в промежуточной модели, которую нужно вернуть (напр. "contact")
 	ThroughPreset string                 `json:"-"` // пресет конечной модели для этой связи (напр. "item")
 	// служебные (только для внутренних вызовов)


### PR DESCRIPTION
## Summary

- add `unique_by` support to `POST /api/index`
- add distinct-value counting via `unique_by` to `POST /api/stats`
- preserve filtering through relations, including `has_many`
- support dotted `belongs_to` and `has_one` paths
- include `null` as a distinct value
- apply sorting and pagination after deduplication
- reject ambiguous `unique_by` paths through `has_many`
- reject combining `unique_by` with stats aggregates
- prevent formatters from materializing missing nested relation contexts
- prevent collisions when relation tails with identical aliases occur in different preset branches
- document the new API behavior

## API examples

Return unique scalar values:

```json
POST /api/index

{
  "model": "Employee",
  "filters": {},
  "unique_by": "position",
  "offset": 0,
  "limit": 20
}

["Developer", "Manager"]